### PR TITLE
Implement i18n support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+require('./src/bot');

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,63 @@
+{
+  "bot": {
+    "unknown_command": "🤔 I don't recognize that command. Try /help."
+  },
+  "buttons": {
+    "help": "📖 Help",
+    "cancel": "❌ Cancel",
+    "back": "⬅️ Back",
+    "new_chord": "🔁 New Chord",
+    "lang": "⚙️ Language"
+  },
+  "commands": {
+    "start": {
+      "welcome": "🎷 *Welcome to Jazz Impro Bot!*\n\n*Quick actions*\n📖 Help – instructions\n❌ Cancel – end session\n\n👇 *Choose a root note to jam*"
+    },
+    "help": {
+      "text": "*How to jam with Jazz Impro Bot* 🎶\n1. Send /start and pick a root note.\n2. Choose the chord quality and an accidental if needed.\n3. I'll suggest a chord a fifth above to inspire your solo.\n\nUse /cancel to stop and /start to begin again."
+    },
+    "cancel": {
+      "done": "🚫 Session cancelled. Use /start when you're ready to jam again.",
+      "no_active": "No active session. Use /start to begin."
+    },
+    "lang": {
+      "set": "Language set to {{lang}}.",
+      "unsupported": "Unsupported language code. Use /lang en or /lang pt.",
+      "choose": "Choose your language:"
+    }
+  },
+  "errors": {
+    "session_expired_restart": "⚠️ Session expired. Send /start to begin again.",
+    "session_timeout": "⌛ Session expired. Use /start to begin again.",
+    "generic": "⚠️ Something went wrong. Please try again later."
+  },
+  "flow": {
+    "choose_root": "*Choose a root note to jam*",
+    "root_chosen": "Root note *{{root}}* chosen! ✅\nChoose the chord quality:",
+    "type_selected": "Quality *{{quality}}* selected! ✅\nAdd an accidental if needed:",
+    "acc_set": "Accidental *{{accidental}}* set! ✅\n\nCalculating…"
+  },
+  "result": {
+    "title": "🎼 <b>Resultado</b>\n",
+    "base_label": "Base chord",
+    "improv_label": "Improv. chord"
+  },
+  "quick": {
+    "help": {
+      "text": "*How to jam with Jazz Impro Bot* 🎶\n1. Send /start and pick a root note.\n2. Choose chord quality and accidental.\n3. I’ll suggest an improvisation chord.\n\nUse /cancel (ou botão Cancelar) para parar."
+    },
+    "cancelled": "❌ Sessão cancelada. Use /start para recomeçar."
+  },
+  "chord_types": {
+    "major": "Major",
+    "minor": "Minor",
+    "dominant": "Dominant",
+    "half_dim": "Half-dim.",
+    "diminished": "Diminished"
+  },
+  "startup": {
+    "no_token": "⚠️  Define the TELEGRAM_TOKEN variable in the .env file",
+    "fake_token": "⚠️  Running with fake token. Polling disabled to avoid 404 error.",
+    "ready": "🤖 Bot successfully started. Awaiting commands..."
+  }
+}

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -1,0 +1,63 @@
+{
+  "bot": {
+    "unknown_command": "🤔 Não reconheço esse comando. Tente /help."
+  },
+  "buttons": {
+    "help": "📖 Ajuda",
+    "cancel": "❌ Cancelar",
+    "back": "⬅️ Voltar",
+    "new_chord": "🔁 Novo Acorde",
+    "lang": "⚙️ Idioma"
+  },
+  "commands": {
+    "start": {
+      "welcome": "🎷 *Bem-vindo ao Jazz Impro Bot!*\n\n*Ações rápidas*\n📖 Ajuda – instruções\n❌ Cancelar – encerrar sessão\n\n👇 *Escolha uma nota para começar a improvisar*"
+    },
+    "help": {
+      "text": "*Como improvisar com o Jazz Impro Bot* 🎶\n1. Envie /start e escolha uma nota.\n2. Escolha a qualidade do acorde e um acidente, se necessário.\n3. Eu sugerirei um acorde uma quinta acima para inspirar seu solo.\n\nUse /cancel para parar e /start para recomeçar."
+    },
+    "cancel": {
+      "done": "🚫 Sessão cancelada. Use /start quando quiser improvisar novamente.",
+      "no_active": "Nenhuma sessão ativa. Use /start para começar."
+    },
+    "lang": {
+      "set": "Idioma definido para {{lang}}.",
+      "unsupported": "Código de idioma não suportado. Use /lang en ou /lang pt.",
+      "choose": "Escolha seu idioma:"
+    }
+  },
+  "errors": {
+    "session_expired_restart": "⚠️ Sessão expirada. Envie /start para começar novamente.",
+    "session_timeout": "⌛ Sessão expirada. Use /start para reiniciar.",
+    "generic": "⚠️ Algo deu errado. Tente novamente mais tarde."
+  },
+  "flow": {
+    "choose_root": "*Escolha uma nota para improvisar*",
+    "root_chosen": "Nota *{{root}}* escolhida! ✅\nEscolha a qualidade do acorde:",
+    "type_selected": "Qualidade *{{quality}}* selecionada! ✅\nAdicione um acidente, se necessário:",
+    "acc_set": "Acidente *{{accidental}}* definido! ✅\n\nCalculando…"
+  },
+  "result": {
+    "title": "🎼 <b>Resultado</b>\n",
+    "base_label": "Acorde base",
+    "improv_label": "Acorde de improviso"
+  },
+  "quick": {
+    "help": {
+      "text": "*Como improvisar com o Jazz Impro Bot* 🎶\n1. Envie /start e escolha uma nota.\n2. Escolha a qualidade e um acidente.\n3. Eu sugerirei um acorde para improvisar.\n\nUse /cancel (ou botão Cancelar) para parar."
+    },
+    "cancelled": "❌ Sessão cancelada. Use /start para recomeçar."
+  },
+  "chord_types": {
+    "major": "Maior",
+    "minor": "Menor",
+    "dominant": "Dominante",
+    "half_dim": "Meio diminuto",
+    "diminished": "Diminuto"
+  },
+  "startup": {
+    "no_token": "⚠️ Defina a variável TELEGRAM_TOKEN no arquivo .env",
+    "fake_token": "⚠️ Rodando com token falso. Polling desativado para evitar erro 404.",
+    "ready": "🤖 Bot iniciado com sucesso. Aguardando comandos..."
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@vitalets/google-translate-api": "^9.2.1",
         "dotenv": "^16.5.0",
         "glob": "^11.0.3",
+        "i18next": "^23.16.8",
+        "i18next-fs-backend": "^2.6.0",
         "node-telegram-bot-api": "^0.66.0"
       },
       "devDependencies": {
@@ -483,6 +485,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4132,6 +4143,35 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.0.tgz",
+      "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest --coverage",
     "repl": "node -i",
     "sync-version": "node scripts/sync-version.js",
-    "prepare": "node scripts/sync-version.js"
+    "prepare": "node scripts/sync-version.js",
+    "i18n:lint": "echo 'TODO'"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +18,8 @@
     "@vitalets/google-translate-api": "^9.2.1",
     "dotenv": "^16.5.0",
     "glob": "^11.0.3",
+    "i18next": "^23.16.8",
+    "i18next-fs-backend": "^2.6.0",
     "node-telegram-bot-api": "^0.66.0"
   },
   "devDependencies": {

--- a/src/bot.js
+++ b/src/bot.js
@@ -9,14 +9,15 @@
 
 require('dotenv').config();
 const TelegramBot = require('node-telegram-bot-api');
+const { t, detectLang } = require('./i18n');
 
 const { state, resetTimeout } = require('./session');
-const { handleStart, handleHelp, handleCancel } = require('./handlers/commands');
+const { handleStart, handleHelp, handleCancel, handleLang } = require('./handlers/commands');
 const { handleCallback } = require('./handlers/callbacks');
 
 const token = process.env.TELEGRAM_TOKEN;
 if (!token) {
-  console.error('⚠️  Define the TELEGRAM_TOKEN variable in the .env file');
+  console.error(t('startup.no_token'));
   process.exit(1);
 }
 
@@ -24,19 +25,21 @@ const isFakeToken = token === 'fake-token';
 const bot = new TelegramBot(token, { polling: !isFakeToken });
 
 if (isFakeToken) {
-  console.warn('⚠️  Running with fake token. Polling disabled to avoid 404 error.');
+  console.warn(t('startup.fake_token'));
 }
 
-console.log('🤖 Bot successfully started. Awaiting commands...');
+console.log(t('startup.ready'));
 
 // Commands
 bot.onText(/\/start/, (msg) => handleStart(bot, msg, state, resetTimeout))
 bot.onText(/\/help/,  (msg) => handleHelp(bot, msg))
 bot.onText(/\/cancel/, (msg) => handleCancel(bot, msg, state))
+bot.onText(/\/lang (\w+)/, (msg, match) => handleLang(bot, msg, state, match[1]))
 
 // Unknown command
-bot.onText(/^\/(?!start|help|cancel).+/, (msg) => {
-  bot.sendMessage(msg.chat.id, "🤔 I don't recognize that command. Try /help.")
+bot.onText(/^\/(?!start|help|cancel|lang).+/, (msg) => {
+  const lng = detectLang(msg);
+  bot.sendMessage(msg.chat.id, t('bot.unknown_command', { lng }));
 })
 
 // Callback queries

--- a/src/handlers/callbacks.js
+++ b/src/handlers/callbacks.js
@@ -3,8 +3,12 @@
 const {
   handleRestart,
   handleShowHelp,
-  handleQuickCancel
+  handleQuickCancel,
+  handleShowLang,
+  handleSetLang
 } = require('./flow/quickActions');
+
+const { t, detectLang } = require('../i18n');
 
 const {
   handleBackToRoot,
@@ -17,15 +21,18 @@ const { handleAccStep } = require('./flow/handleAccidental');
 
 async function handleCallback(query, bot, state, resetTimeout) {
   const chatId = query.message.chat.id;
+  const lng = detectLang(query.message);
 
   if (query.data === 'restart') return handleRestart(query, bot, state, resetTimeout);
-  if (query.data === 'show_help') return handleShowHelp(query, bot);
+  if (query.data === 'show_help') return handleShowHelp(query, bot, state);
   if (query.data === 'quick_cancel') return handleQuickCancel(query, bot, state);
+  if (query.data === 'show_lang') return handleShowLang(query, bot, state);
+  if (query.data.startsWith('set_lang:')) return handleSetLang(query, bot, state, resetTimeout);
   if (query.data === 'back:root') return handleBackToRoot(query, bot, state);
   if (query.data === 'back:type') return handleBackToType(query, bot, state);
 
   if (!state[chatId]) {
-    return bot.sendMessage(chatId, '⚠️ Session expired. Send /start to begin again.');
+    return bot.sendMessage(chatId, t('errors.session_expired_restart', { lng }));
   }
 
   try {
@@ -35,7 +42,7 @@ async function handleCallback(query, bot, state, resetTimeout) {
     if (step === 'acc') return handleAccStep(query, bot, state);
   } catch (err) {
     console.error(err);
-    bot.sendMessage(query.message.chat.id, '⚠️ Something went wrong. Please try again later.');
+    bot.sendMessage(query.message.chat.id, t('errors.generic', { lng }));
   }
 }
 

--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -7,58 +7,64 @@
 // src/handlers/commands.js
 
 const { ROOTS, twoColumn } = require('../keyboards');
+const { t, detectLang } = require('../i18n');
 
 function handleStart(bot, msg, state, resetTimeout) {
   const chatId = msg.chat.id
-  state[chatId] = { step: 'root' }
+  const lng = detectLang(msg)
+  state[chatId] = { step: 'root', lang: lng }
 
   const rootKeyboard = twoColumn(
     ROOTS.map(r => ({ text: r, callback_data: `root:${r}` }))
   )
   const quickRow = [
-    { text: '📖 Help',   callback_data: 'show_help' },
-    { text: '❌ Cancel', callback_data: 'quick_cancel' }
+    { text: t('buttons.help', { lng }), callback_data: 'show_help' },
+    { text: t('buttons.cancel', { lng }), callback_data: 'quick_cancel' },
+    { text: t('buttons.lang', { lng }), callback_data: 'show_lang' }
   ]
 
-  const text =
-    '🎷 *Welcome to Jazz Impro Bot!*\n\n' +
-    '*Quick actions*\n' +
-    '📖 Help – instructions\n' +
-    '❌ Cancel – end session\n\n' +
-    '👇 *Choose a root note to jam*'
+  const text = t('commands.start.welcome', { lng })
 
   bot.sendMessage(chatId, text, {
     parse_mode: 'Markdown',
     reply_markup: { inline_keyboard: [quickRow, ...rootKeyboard] }
   }).then(sent => {
     state[chatId].msgId = sent.message_id
-    resetTimeout(chatId, bot)
+    resetTimeout(chatId, bot, t('errors.session_timeout', { lng }))
   })
 }
 
 function handleHelp(bot, msg) {
   const chatId = msg.chat.id
-  const text =
-    '*How to jam with Jazz Impro Bot* 🎶\n' +
-    '1. Send /start and pick a root note.\n' +
-    '2. Choose the chord quality and an accidental if needed.\n' +
-    "3. I'll suggest a chord a fifth above to inspire your solo.\n\n" +
-    'Use /cancel to stop and /start to begin again.'
+  const lng = detectLang(msg)
+  const text = t('commands.help.text', { lng })
   bot.sendMessage(chatId, text, { parse_mode: 'Markdown' })
 }
 
 function handleCancel(bot, msg, state) {
   const chatId = msg.chat.id
+  const lng = detectLang(msg)
   if (state[chatId]) {
     if (state[chatId].timer) clearTimeout(state[chatId].timer)
     delete state[chatId]
     bot.sendMessage(
       chatId,
-      "🚫 Session cancelled. Use /start when you're ready to jam again."
+      t('commands.cancel.done', { lng })
     )
   } else {
-    bot.sendMessage(chatId, 'No active session. Use /start to begin.')
+    bot.sendMessage(chatId, t('commands.cancel.no_active', { lng }))
   }
 }
 
-module.exports = { handleStart, handleHelp, handleCancel }
+function handleLang(bot, msg, state, code) {
+  const chatId = msg.chat.id
+  const lng = detectLang(msg)
+  if (!['en', 'pt'].includes(code)) {
+    return bot.sendMessage(chatId, t('commands.lang.unsupported', { lng }))
+  }
+  if (!state[chatId]) state[chatId] = {}
+  state[chatId].lang = code
+  return bot.sendMessage(chatId, t('commands.lang.set', { lng: code, lang: code }))
+}
+
+module.exports = { handleStart, handleHelp, handleCancel, handleLang }

--- a/src/handlers/flow/backNavigation.js
+++ b/src/handlers/flow/backNavigation.js
@@ -7,18 +7,20 @@
 // src/handlers/flow/backNavigation.js
 
 const { ROOTS, TYPES, twoColumn } = require('../../keyboards');
+const { t, detectLang } = require('../../i18n');
 
 async function handleBackToRoot(query, bot, state) {
   const chatId = query.message.chat.id;
+  const lng = state[chatId].lang || detectLang(query.message);
 
-  state[chatId] = { step: 'root', msgId: state[chatId].msgId };
+  state[chatId] = { step: 'root', msgId: state[chatId].msgId, lang: lng };
 
   const kb = twoColumn(
     ROOTS.map(r => ({ text: r, callback_data: `root:${r}` }))
   );
 
   await bot.editMessageText(
-    '*Choose a root note to jam*',
+    t('flow.choose_root', { lng }),
     {
       chat_id: chatId,
       message_id: state[chatId].msgId,
@@ -30,16 +32,17 @@ async function handleBackToRoot(query, bot, state) {
 
 async function handleBackToType(query, bot, state) {
   const chatId = query.message.chat.id;
+  const lng = state[chatId].lang || detectLang(query.message);
 
   state[chatId].step = 'type';
 
   const kb = [
-    [{ text: '⬅️ Back', callback_data: 'back:root' }],
-    ...TYPES.map(t => [t])
+    [{ text: t('buttons.back', { lng }), callback_data: 'back:root' }],
+    ...TYPES.map(tObj => [{ text: t(`chord_types.${tObj.key}`, { lng }), callback_data: tObj.callback_data }])
   ];
 
   await bot.editMessageText(
-    `Root note *${state[chatId].root}* chosen! ✅\nChoose the chord quality:`,
+    t('flow.root_chosen', { lng, root: state[chatId].root }),
     {
       chat_id: chatId,
       message_id: state[chatId].msgId,

--- a/src/handlers/flow/handleAccidental.js
+++ b/src/handlers/flow/handleAccidental.js
@@ -8,6 +8,7 @@
 
 const { Chord } = require('../../chord');
 const { getImprovisationChord } = require('../../improvisation');
+const { t, detectLang } = require('../../i18n');
 
 function pad(str, len = 25) {
   return str.length >= len ? str : str + ' '.repeat(len - str.length);
@@ -16,9 +17,10 @@ function pad(str, len = 25) {
 async function handleAccStep(query, bot, state) {
   const chatId = query.message.chat.id;
   const [, value] = query.data.split(':');
+  const lng = state[chatId].lang || detectLang(query.message);
 
   await bot.editMessageText(
-    `Accidental *${value || 'none'}* set! ✅\n\nCalculating…`,
+    t('flow.acc_set', { lng, accidental: value || 'none' }),
     {
       chat_id: chatId,
       message_id: state[chatId].msgId,
@@ -38,10 +40,10 @@ async function handleAccStep(query, bot, state) {
   const improvLabel = `${improvChord.toString().split(':')[0]} (${improvChord.getNotes().join(' ')})`;
 
   const htmlResult =
-    '🎼 <b>Resultado</b>\n' +
+    t('result.title', { lng }) +
     '<pre>' +
-    `${pad('Base chord')} | ${baseLabel}\n` +
-    `${pad('Improv. chord')} | ${improvLabel}\n` +
+    `${pad(t('result.base_label', { lng }))} | ${baseLabel}\n` +
+    `${pad(t('result.improv_label', { lng }))} | ${improvLabel}\n` +
     '</pre>';
 
   await bot.editMessageText(htmlResult, {
@@ -49,7 +51,7 @@ async function handleAccStep(query, bot, state) {
     message_id: state[chatId].msgId,
     parse_mode: 'HTML',
     reply_markup: {
-      inline_keyboard: [[{ text: '🔁 New Chord', callback_data: 'restart' }]]
+      inline_keyboard: [[{ text: t('buttons.new_chord', { lng }), callback_data: 'restart' }]]
     }
   });
 

--- a/src/handlers/flow/handleRoot.js
+++ b/src/handlers/flow/handleRoot.js
@@ -7,22 +7,30 @@
 // src/handlers/flow/handleRoot.js
 
 const { TYPES } = require('../../keyboards');
+const { t, detectLang } = require('../../i18n');
 
 async function handleRootStep(query, bot, state, resetTimeout) {
   const chatId = query.message.chat.id;
   const [, value] = query.data.split(':');
 
+  const lng = state[chatId].lang || detectLang(query.message);
+
   state[chatId].root = value;
   state[chatId].step = 'type';
-  resetTimeout(chatId, bot);
+  resetTimeout(chatId, bot, t('errors.session_timeout', { lng }));
 
   const kb = [
-    [{ text: '⬅️ Back', callback_data: 'back:root' }],
-    ...TYPES.map(t => [t])
+    [{ text: t('buttons.back', { lng }), callback_data: 'back:root' }],
+    ...TYPES.map(tObj => [
+      {
+        text: t(`chord_types.${tObj.key}`, { lng }),
+        callback_data: tObj.callback_data
+      }
+    ])
   ];
 
   await bot.editMessageText(
-    `Root note *${value}* chosen! ✅\nChoose the chord quality:`,
+    t('flow.root_chosen', { lng, root: value }),
     {
       chat_id: chatId,
       message_id: state[chatId].msgId,

--- a/src/handlers/flow/handleType.js
+++ b/src/handlers/flow/handleType.js
@@ -7,22 +7,25 @@
 // src/handlers/flow/handleType.js
 
 const { ACCS } = require('../../keyboards');
+const { t, detectLang } = require('../../i18n');
 
 async function handleTypeStep(query, bot, state, resetTimeout) {
   const chatId = query.message.chat.id;
   const [, value] = query.data.split(':');
 
+  const lng = state[chatId].lang || detectLang(query.message);
+
   state[chatId].type = value;
   state[chatId].step = 'acc';
-  resetTimeout(chatId, bot);
+  resetTimeout(chatId, bot, t('errors.session_timeout', { lng }));
 
   const kb = [
-    [{ text: '⬅️ Back', callback_data: 'back:type' }],
+    [{ text: t('buttons.back', { lng }), callback_data: 'back:type' }],
     ...ACCS.map(a => [a])
   ];
 
   await bot.editMessageText(
-    `Quality *${value}* selected! ✅\nAdd an accidental if needed:`,
+    t('flow.type_selected', { lng, quality: value }),
     {
       chat_id: chatId,
       message_id: state[chatId].msgId,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const i18next = require('i18next');
+const Backend = require('i18next-fs-backend');
+const { state } = require('./session');
+
+function detectLang(msg) {
+  return state[msg.chat.id]?.lang || msg.from.language_code || 'en';
+}
+
+i18next
+  .use(Backend)
+  .init({
+    initImmediate: false,
+    fallbackLng: 'en',
+    returnEmptyString: false,
+    preload: ['en', 'pt'],
+    backend: {
+      loadPath: path.join(__dirname, '..', 'locales/{{lng}}/translation.json')
+    }
+  });
+
+module.exports = { t: i18next.t.bind(i18next), detectLang };

--- a/src/keyboards.js
+++ b/src/keyboards.js
@@ -8,11 +8,11 @@
 
 const ROOTS = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
 const TYPES = [
-  { text: 'Major', callback_data: 'type:maj7' },
-  { text: 'Minor', callback_data: 'type:m7' },
-  { text: 'Dominant', callback_data: 'type:7' },
-  { text: 'Half-dim.', callback_data: 'type:m7b5' },
-  { text: 'Diminished', callback_data: 'type:dim7' }
+  { key: 'major', callback_data: 'type:maj7' },
+  { key: 'minor', callback_data: 'type:m7' },
+  { key: 'dominant', callback_data: 'type:7' },
+  { key: 'half_dim', callback_data: 'type:m7b5' },
+  { key: 'diminished', callback_data: 'type:dim7' }
 ]
 const ACCS = [
   { text: '♮', callback_data: 'acc:' },

--- a/src/session.js
+++ b/src/session.js
@@ -9,12 +9,12 @@
 const state = {};
 const SESSION_TTL_MS = 5 * 60 * 1000;
 
-function resetTimeout(chatId, bot) {
+function resetTimeout(chatId, bot, text) {
   if (state[chatId]?.timer) clearTimeout(state[chatId].timer)
   state[chatId].timer = setTimeout(() => {
     if (state[chatId]) {
       delete state[chatId]
-      bot.sendMessage(chatId, '⌛ Session expired. Use /start to begin again.')
+      bot.sendMessage(chatId, text)
     }
   }, SESSION_TTL_MS)
 }


### PR DESCRIPTION
## Summary
- add i18next setup and language detection
- translate all user-facing text
- add /lang command and language buttons
- provide English and Portuguese translation skeletons
- wire new keyboards and session timeout handling

## Testing
- `node -c src/i18n.js`
- `node -c src/handlers/commands.js`
- `node -c src/handlers/callbacks.js`
- `node -c src/handlers/flow/backNavigation.js`
- `node -c src/handlers/flow/handleRoot.js`
- `node -c src/handlers/flow/handleType.js`
- `node -c src/handlers/flow/handleAccidental.js`
- `node -c src/handlers/flow/quickActions.js`
- `node -c src/keyboards.js`
- `node -c src/bot.js`
- `node .` *(fails: Cannot find module 'i18next')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858235682bc832cacf92cc50506187b