### PR TITLE
Refactor session structure and keyboards

### DIFF
--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -11,7 +11,7 @@
   },
   "commands": {
     "start": {
-      "welcome": "🎷 *Bem-vindo ao Jazz Impro Bot!*\n\n*Ações rápidas*\n📖 Ajuda – instruções\n❌ Cancelar – encerrar sessão\n\n👇 *Escolha uma nota para começar a improvisar*"
+      "welcome": "🎷 *Bem-vindo ao Jazz Impro Bot!*\n\n*Ações rápidas*\n📖 Ajuda – instruções\n❌ Cancelar – encerrar sessão\n\n👇 *Escolha uma nota para improvisar*"
     },
     "help": {
       "text": "*Como improvisar com o Jazz Impro Bot* 🎶\n1. Envie /start e escolha uma nota.\n2. Escolha a qualidade do acorde e um acidente, se necessário.\n3. Eu sugerirei um acorde uma quinta acima para inspirar seu solo.\n\nUse /cancel para parar e /start para recomeçar."
@@ -44,7 +44,7 @@
   },
   "quick": {
     "help": {
-      "text": "*Como improvisar com o Jazz Impro Bot* 🎶\n1. Envie /start e escolha uma nota.\n2. Escolha a qualidade e um acidente.\n3. Eu sugerirei um acorde para improvisar.\n\nUse /cancel (ou botão Cancelar) para parar."
+      "text": "*Como improvisar com o Jazz Impro Bot* 🎶\n1. Envie /start e escolha uma nota.\n2. Escolha qualidade e acidente.\n3. Sugerirei um acorde para improvisar.\n\nUse /cancel (ou botão Cancelar) para parar."
     },
     "cancelled": "❌ Sessão cancelada. Use /start para recomeçar."
   },

--- a/src/handlers/callbacks.js
+++ b/src/handlers/callbacks.js
@@ -31,7 +31,7 @@ async function handleCallback(query, bot, state, resetTimeout) {
   if (query.data === 'back:root') return handleBackToRoot(query, bot, state);
   if (query.data === 'back:type') return handleBackToType(query, bot, state);
 
-  if (!state[chatId]) {
+  if (!state[chatId]?.session) {
     return bot.sendMessage(chatId, t('errors.session_expired_restart', { lng }));
   }
 

--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -15,6 +15,10 @@ function handleStart(bot, msg, state, resetTimeout) {
   const prefs = getPrefs(chatId)
   const lng = prefs.lang || detectLang(msg)
 
+  const oldId = state[chatId]?.session?.msgId
+  if (oldId) bot.deleteMessage(chatId, oldId).catch(() => {})
+
+  clearSession(chatId)
   const session = getSession(chatId)
   session.step = 'root'
 
@@ -23,13 +27,15 @@ function handleStart(bot, msg, state, resetTimeout) {
 
   const text = t('commands.start.welcome', { lng })
 
-  bot.sendMessage(chatId, text, {
-    parse_mode: 'Markdown',
-    reply_markup: { inline_keyboard: [quickRow, ...rootKeyboard] }
-  }).then(sent => {
-    session.msgId = sent.message_id
-    resetTimeout(chatId, bot, t('errors.session_timeout', { lng }))
-  })
+  bot
+    .sendMessage(chatId, text, {
+      parse_mode: 'Markdown',
+      reply_markup: { inline_keyboard: [quickRow, ...rootKeyboard] }
+    })
+    .then(sent => {
+      session.msgId = sent.message_id
+      resetTimeout(chatId, bot, t('errors.session_timeout', { lng }))
+    })
 }
 
 function handleHelp(bot, msg) {

--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -22,7 +22,7 @@ function handleStart(bot, msg, state, resetTimeout) {
   const session = getSession(chatId)
   session.step = 'root'
 
-  const rootKeyboard = getRootKeyboard(lng, 3)
+  const rootKeyboard = getRootKeyboard(lng, 2)
   const quickRow = getQuickRow(lng)
 
   const text = t('commands.start.welcome', { lng })

--- a/src/handlers/flow/backNavigation.js
+++ b/src/handlers/flow/backNavigation.js
@@ -18,7 +18,7 @@ async function handleBackToRoot(query, bot, state) {
   const session = getSession(chatId);
   session.step = 'root';
 
-  const kb = getRootKeyboard(lng, 3);
+  const kb = getRootKeyboard(lng, 2);
 
   await bot.editMessageText(
     t('flow.choose_root', { lng }),

--- a/src/handlers/flow/handleType.js
+++ b/src/handlers/flow/handleType.js
@@ -6,29 +6,32 @@
 
 // src/handlers/flow/handleType.js
 
-const { ACCS } = require('../../keyboards');
+const { ACCS, threeColumn } = require('../../keyboards');
 const { t, detectLang } = require('../../i18n');
+const { getPrefs, getSession } = require('../../session');
 
 async function handleTypeStep(query, bot, state, resetTimeout) {
   const chatId = query.message.chat.id;
   const [, value] = query.data.split(':');
 
-  const lng = state[chatId].lang || detectLang(query.message);
+  const prefs = getPrefs(chatId);
+  const lng = prefs.lang || detectLang(query.message);
 
-  state[chatId].type = value;
-  state[chatId].step = 'acc';
+  const session = getSession(chatId);
+  session.type = value;
+  session.step = 'acc';
   resetTimeout(chatId, bot, t('errors.session_timeout', { lng }));
 
   const kb = [
     [{ text: t('buttons.back', { lng }), callback_data: 'back:type' }],
-    ...ACCS.map(a => [a])
+    ...threeColumn(ACCS)
   ];
 
   await bot.editMessageText(
     t('flow.type_selected', { lng, quality: value }),
     {
       chat_id: chatId,
-      message_id: state[chatId].msgId,
+      message_id: session.msgId,
       parse_mode: 'Markdown',
       reply_markup: { inline_keyboard: kb }
     }

--- a/src/handlers/flow/quickActions.js
+++ b/src/handlers/flow/quickActions.js
@@ -16,19 +16,18 @@ async function handleRestart(query, bot, state, resetTimeout) {
   const prefs = getPrefs(chatId);
   const lng = prefs.lang || detectLang(query.message);
 
-  const messageId = query.message.message_id;
+  const session = getSession(chatId);
+  const messageId = session.msgId || query.message.message_id;
 
-  const prevId = state[chatId]?.session?.msgId;
-  if (prevId && prevId !== messageId) {
-    bot.deleteMessage(chatId, prevId).catch(() => {});
+  const prevId = session.msgId;
+  if (!prevId) {
+    session.msgId = messageId;
   }
 
-  const session = getSession(chatId);
   session.step = 'root';
-  session.msgId = messageId;
   resetTimeout(chatId, bot, t('errors.session_timeout', { lng }));
 
-  const rootKB = getRootKeyboard(lng, 3);
+  const rootKB = getRootKeyboard(lng, 2);
   const quickRow = getQuickRow(lng);
 
   await bot.editMessageText(

--- a/src/handlers/flow/quickActions.js
+++ b/src/handlers/flow/quickActions.js
@@ -16,7 +16,12 @@ async function handleRestart(query, bot, state, resetTimeout) {
   const prefs = getPrefs(chatId);
   const lng = prefs.lang || detectLang(query.message);
 
-  const messageId = state[chatId]?.session?.msgId || query.message.message_id;
+  const messageId = query.message.message_id;
+
+  const prevId = state[chatId]?.session?.msgId;
+  if (prevId && prevId !== messageId) {
+    bot.deleteMessage(chatId, prevId).catch(() => {});
+  }
 
   const session = getSession(chatId);
   session.step = 'root';

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,7 +4,7 @@ const Backend = require('i18next-fs-backend');
 const { state } = require('./session');
 
 function detectLang(msg) {
-  return state[msg.chat.id]?.lang || msg.from.language_code || 'en';
+  return state[msg.chat.id]?.prefs?.lang || msg.from.language_code || 'en';
 }
 
 i18next

--- a/src/keyboards.js
+++ b/src/keyboards.js
@@ -6,6 +6,8 @@
 
 // src/keyboards.js
 
+const { t } = require('./i18n')
+
 const ROOTS = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
 const TYPES = [
   { key: 'major', callback_data: 'type:maj7' },
@@ -20,14 +22,42 @@ const ACCS = [
   { text: '♯', callback_data: 'acc:#' },
 ]
 
-function twoColumn(buttons) {
+function nColumn(buttons, n) {
   const keyboard = []
-  for (let i = 0; i < buttons.length; i += 2) {
-    const row = [buttons[i]]
-    if (buttons[i + 1]) row.push(buttons[i + 1])
-    keyboard.push(row)
+  for (let i = 0; i < buttons.length; i += n) {
+    keyboard.push(buttons.slice(i, i + n))
   }
   return keyboard
 }
 
-module.exports = { ROOTS, TYPES, ACCS, twoColumn }
+function twoColumn(arr) {
+  return nColumn(arr, 2)
+}
+
+function threeColumn(arr) {
+  return nColumn(arr, 3)
+}
+
+function getQuickRow(lng) {
+  return [
+    { text: t('buttons.help', { lng }), callback_data: 'show_help' },
+    { text: t('buttons.cancel', { lng }), callback_data: 'quick_cancel' },
+    { text: t('buttons.lang', { lng }), callback_data: 'show_lang' }
+  ]
+}
+
+function getRootKeyboard(lng, nCols = 3) {
+  const btns = ROOTS.map(r => ({ text: r, callback_data: `root:${r}` }))
+  return nColumn(btns, nCols)
+}
+
+module.exports = {
+  ROOTS,
+  TYPES,
+  ACCS,
+  nColumn,
+  twoColumn,
+  threeColumn,
+  getQuickRow,
+  getRootKeyboard,
+}

--- a/src/keyboards.js
+++ b/src/keyboards.js
@@ -46,7 +46,7 @@ function getQuickRow(lng) {
   ]
 }
 
-function getRootKeyboard(lng, nCols = 3) {
+function getRootKeyboard(lng, nCols = 2) {
   const btns = ROOTS.map(r => ({ text: r, callback_data: `root:${r}` }))
   return nColumn(btns, nCols)
 }

--- a/src/session.js
+++ b/src/session.js
@@ -6,17 +6,35 @@
 
 // src/session.js
 
-const state = {};
-const SESSION_TTL_MS = 5 * 60 * 1000;
+const state = {}
+const SESSION_TTL_MS = 5 * 60 * 1000
+
+function getPrefs(chatId) {
+  if (!state[chatId]) state[chatId] = {}
+  if (!state[chatId].prefs) state[chatId].prefs = {}
+  return state[chatId].prefs
+}
+
+function getSession(chatId) {
+  if (!state[chatId]) state[chatId] = {}
+  if (!state[chatId].session) state[chatId].session = {}
+  return state[chatId].session
+}
+
+function clearSession(chatId) {
+  if (state[chatId]?.session?.timer) clearTimeout(state[chatId].session.timer)
+  if (state[chatId]) delete state[chatId].session
+}
 
 function resetTimeout(chatId, bot, text) {
-  if (state[chatId]?.timer) clearTimeout(state[chatId].timer)
-  state[chatId].timer = setTimeout(() => {
-    if (state[chatId]) {
-      delete state[chatId]
+  const sess = getSession(chatId)
+  if (sess.timer) clearTimeout(sess.timer)
+  sess.timer = setTimeout(() => {
+    if (state[chatId]?.session) {
+      delete state[chatId].session
       bot.sendMessage(chatId, text)
     }
   }, SESSION_TTL_MS)
 }
 
-module.exports = { state, resetTimeout }
+module.exports = { state, resetTimeout, getPrefs, getSession, clearSession }


### PR DESCRIPTION
## Summary
- persist user language in preferences and keep session separate
- align keyboards via new generic column utilities
- preserve language across restarts and clean up sessions correctly
- support language change with live restart

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685835b86594832c9f06182a00cb570d